### PR TITLE
pool deletion fix and added tests for it

### DIFF
--- a/contracts/StableAssetApplication.sol
+++ b/contracts/StableAssetApplication.sol
@@ -392,21 +392,31 @@ contract StableAssetApplication is Initializable, ReentrancyGuardUpgradeable {
    */
   function updatePool(address _swap, bool _enabled) external {
     require(msg.sender == governance, "not governance");
-    if (_enabled && !allowedPoolAddress[_swap]) {
-      pools.push(_swap);
+
+    if (_enabled) {
+      // If _enabled is true and the pool is not already allowed
+      if (!allowedPoolAddress[_swap]) {
+        // Add the pool to the pools array
+        pools.push(_swap);
+      }
     } else {
-      address[] memory updatedPools;
-      uint256 index = 0;
-      for (uint256 i = 0; i < pools.length; i++) {
-        if (pools[i] != _swap) {
-          updatedPools[index] = pools[i];
-          index++;
+      // If _enabled is false, find and remove the pool from the pools array
+      uint256 length = pools.length;
+      for (uint256 i = 0; i < length; i++) {
+        if (pools[i] == _swap) {
+          // Replace the pool to be removed with the last pool in the array
+          pools[i] = pools[length - 1];
+          // Remove the last element
+          pools.pop();
+          break; // Exit the loop once the pool is found and removed
         }
       }
-      pools = updatedPools;
     }
+
+    // Update the allowedPoolAddress mapping
     allowedPoolAddress[_swap] = _enabled;
 
+    // Emit the PoolModified event
     emit PoolModified(_swap, _enabled);
   }
 

--- a/test/StableAssetApplication.ts
+++ b/test/StableAssetApplication.ts
@@ -158,6 +158,30 @@ describe("StableAssetApplication", function () {
     return { swapOne, swapTwo, wETH, token1, token2, poolToken, application };
   }
 
+  it("should remove the pool from pools array when _enabled is false", async () => {
+    /// Deploy swap and tokens
+    const { swap, application } =
+      await loadFixture(deploySwapAndTokens);
+
+    // Ensure the pool is initially added
+    await application.updatePool(swap.address, true);
+
+    // Verify that the pool was added
+    let pools = await application.pools(0); // Directly access the first element of the public state variable
+    expect(pools).to.equal(swap.address);
+
+    // Disable the pool
+    await application.updatePool(swap.address, false);
+
+    // Verify that the pool was removed
+    try {
+      pools = await application.pools(0); // This should now throw an error or return an empty value
+      expect(pools).to.not.equal(swap.address);
+    } catch (error) {
+      console.log("Pool removed successfully");
+    }
+  });
+
   it("should mint", async () => {
     /// Deploy swap and tokens
     const { swap, wETH, token2, poolToken, application } = await loadFixture(

--- a/test/docs/StableAssetApplication.md
+++ b/test/docs/StableAssetApplication.md
@@ -19,6 +19,7 @@
 - Set minter of pool token to be swapOne contract
 - Set minter of pool token to be swapTwo contract
 - Deploy swap and tokens
+- Deploy swap and tokens
 - Unpause swap contract
 - Mint 100 token2 to user
 - Approve application contract to spend 100 token2


### PR DESCRIPTION
Tasks Worked on:
-Optimized the updatePool function in contracts/StableAssetApplication.sol
-Created tests in test/StableAssetApplication.ts to check add/delete function

I have optimized the code to delete pools in StableAssetApplication.sol in contracts, instead of copying over the entire new array into a memory variable now we are just swapping and deleting the element from pools itself. This reduces space complexity from O(n) to O(1). 
<img width="721" alt="Screenshot 2024-05-28 at 4 05 30 PM" src="https://github.com/nutsfinance/tapio-eth/assets/95612797/b83a1c98-e8e2-4e00-b622-15c7de4aaa93">
The problem talked about in the issue, that the pool was not being deleted from pools when _enabled is set to false. I created a test for this task in StableAssetApplication.ts in test folder
<img width="843" alt="Screenshot 2024-05-28 at 4 08 07 PM" src="https://github.com/nutsfinance/tapio-eth/assets/95612797/6a8c47ab-5e2f-4eed-9359-8721afad1b16">
What i found was the function was working properly if _enabled was false by running multiple tests but in case if the pool address is already added and the updatePool is called with the same address with _enabled true it will delete the pool since the condition is !allowedAddressPool[address].