### PR TITLE
fix: mixbytes re-audit findings resolving

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -36,6 +36,7 @@
   quote_style = "double"
   tab_width = 4
   wrap_comments = true
+  single_line_statement_blocks = "preserve"
 
 [rpc_endpoints]
   arbitrum = "https://arb1.arbitrum.io/rpc"

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -58,6 +58,7 @@ contract Deploy is Config {
                 wlpTokenBeacon,
                 rampAControllerBeacon,
                 new ConstantExchangeRateProvider(),
+                0,
                 0
             )
         );

--- a/src/SelfPeggingAsset.sol
+++ b/src/SelfPeggingAsset.sol
@@ -1197,7 +1197,7 @@ contract SelfPeggingAsset is Initializable, ReentrancyGuardUpgradeable, OwnableU
             return;
         }
 
-        uint256 ratio = (diff * FEE_DENOMINATOR) / oldRate;
+        uint256 ratio = (diff * FEE_DENOMINATOR) / (oldRate > newRate ? oldRate : newRate);
         uint256 candidateMultiplier = FEE_DENOMINATOR + (ratio * exchangeRateFeeFactor) / FEE_DENOMINATOR;
         uint256 currentMult = _currentMultiplier(st);
 

--- a/src/SelfPeggingAsset.sol
+++ b/src/SelfPeggingAsset.sol
@@ -273,6 +273,16 @@ contract SelfPeggingAsset is Initializable, ReentrancyGuardUpgradeable, OwnableU
      */
     event DecayPeriodModified(uint256 decayPeriod);
 
+    /**
+     * @dev This event is emitted when the pool is paused.
+     */
+    event PoolPaused();
+
+    /**
+     * @dev This event is emitted when the pool is unpaused.
+     */
+    event PoolUnpaused();
+
     /// @notice Error thrown when the input parameters do not match the expected values.
     error InputMismatch();
 
@@ -851,6 +861,7 @@ contract SelfPeggingAsset is Initializable, ReentrancyGuardUpgradeable, OwnableU
         require(admins[msg.sender], NotAdmin());
 
         paused = true;
+        emit PoolPaused();
     }
 
     /**
@@ -861,6 +872,7 @@ contract SelfPeggingAsset is Initializable, ReentrancyGuardUpgradeable, OwnableU
         require(admins[msg.sender], NotAdmin());
 
         paused = false;
+        emit PoolUnpaused();
     }
 
     /**

--- a/src/SelfPeggingAsset.sol
+++ b/src/SelfPeggingAsset.sol
@@ -70,7 +70,7 @@ contract SelfPeggingAsset is Initializable, ReentrancyGuardUpgradeable, OwnableU
     /**
      * @dev This is the default rate change skip period
      */
-    uint256 private constant DEFAULT_RATE_CHANGE_SKIP_PERIOD = 1 hours;
+    uint256 private constant DEFAULT_RATE_CHANGE_SKIP_PERIOD = 1 days;
 
     /**
      * @dev This is an array of addresses representing the tokens currently supported by the SelfPeggingAsset contract.
@@ -690,7 +690,6 @@ contract SelfPeggingAsset is Initializable, ReentrancyGuardUpgradeable, OwnableU
         // After reducing the redeem fee, the remaining pool tokens are burned!
         poolToken.burnSharesFrom(msg.sender, _amount);
         feeAmount = collectFeeOrYield(true);
-        lastActivity = block.timestamp;
         emit Redeemed(msg.sender, _amount, amounts, feeAmount);
         return amounts;
     }
@@ -967,7 +966,6 @@ contract SelfPeggingAsset is Initializable, ReentrancyGuardUpgradeable, OwnableU
         }
         totalSupply = newD;
         poolToken.addBuffer(donationAmount);
-        lastActivity = block.timestamp;
 
         emit Donated(msg.sender, donationAmount, _amounts);
 
@@ -1011,7 +1009,6 @@ contract SelfPeggingAsset is Initializable, ReentrancyGuardUpgradeable, OwnableU
 
         balances = _balances;
         totalSupply = newD;
-        lastActivity = block.timestamp;
     }
 
     /**
@@ -1021,7 +1018,6 @@ contract SelfPeggingAsset is Initializable, ReentrancyGuardUpgradeable, OwnableU
     function rebase() external returns (uint256) {
         uint256[] memory _balances = balances;
         uint256 oldD = totalSupply;
-        lastActivity = block.timestamp;
 
         for (uint256 i = 0; i < _balances.length; i++) {
             uint256 balanceI = IERC20(tokens[i]).balanceOf(address(this));

--- a/src/SelfPeggingAssetFactory.sol
+++ b/src/SelfPeggingAssetFactory.sol
@@ -126,6 +126,11 @@ contract SelfPeggingAssetFactory is UUPSUpgradeable, OwnableUpgradeable {
     uint256 public exchangeRateFeeFactor;
 
     /**
+     * @dev The buffer percent for the LPToken.
+     */
+    uint256 public bufferPercent;
+
+    /**
      * @dev This event is emitted when the governor is modified.
      * @param governor is the new value of the governor.
      */
@@ -182,6 +187,12 @@ contract SelfPeggingAssetFactory is UUPSUpgradeable, OwnableUpgradeable {
      */
     event MinRampTimeUpdated(uint256 minRampTime);
 
+    /**
+     * @dev This event is emitted when the buffer percent is updated.
+     * @param bufferPercent is the new value of the buffer percent.
+     */
+    event BufferPercentUpdated(uint256 bufferPercent);
+
     /// @dev Error thrown when the address is invalid
     error InvalidAddress();
 
@@ -214,7 +225,8 @@ contract SelfPeggingAssetFactory is UUPSUpgradeable, OwnableUpgradeable {
         address _wlpTokenBeacon,
         address _rampAControllerBeacon,
         ConstantExchangeRateProvider _constantExchangeRateProvider,
-        uint256 _exchangeRateFeeFactor
+        uint256 _exchangeRateFeeFactor,
+        uint256 _bufferPercent
     )
         public
         initializer
@@ -244,6 +256,7 @@ contract SelfPeggingAssetFactory is UUPSUpgradeable, OwnableUpgradeable {
         offPegFeeMultiplier = _offPegFeeMultiplier;
         minRampTime = _minRampTime;
         exchangeRateFeeFactor = _exchangeRateFeeFactor;
+        bufferPercent = _bufferPercent;
     }
 
     /**
@@ -310,6 +323,11 @@ contract SelfPeggingAssetFactory is UUPSUpgradeable, OwnableUpgradeable {
     function setExchangeRateFeeFactor(uint256 _exchangeRateFeeFactor) external onlyOwner {
         exchangeRateFeeFactor = _exchangeRateFeeFactor;
         emit ExchangeRateFeeFactorModified(_exchangeRateFeeFactor);
+    }
+
+    function setBufferPercent(uint256 _bufferPercent) external onlyOwner {
+        bufferPercent = _bufferPercent;
+        emit BufferPercentUpdated(_bufferPercent);
     }
 
     /**
@@ -395,6 +413,7 @@ contract SelfPeggingAssetFactory is UUPSUpgradeable, OwnableUpgradeable {
         selfPeggingAsset.setAdmin(governor, true);
         selfPeggingAsset.transferOwnership(governor);
         lpToken.addPool(address(selfPeggingAsset));
+        lpToken.setBuffer(bufferPercent);
         lpToken.transferOwnership(governor);
         rampAConotroller.transferOwnership(governor);
 

--- a/src/WLPToken.sol
+++ b/src/WLPToken.sol
@@ -46,6 +46,7 @@ contract WLPToken is ERC4626Upgradeable {
         shares = convertToShares(assets);
         lpToken.transferFrom(msg.sender, address(this), assets);
         _mint(receiver, shares);
+        emit Deposit(msg.sender, receiver, assets, shares);
     }
 
     /**
@@ -65,6 +66,8 @@ contract WLPToken is ERC4626Upgradeable {
 
         // Mint the shares to the receiver
         _mint(receiver, shares);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
     }
 
     /**
@@ -84,6 +87,7 @@ contract WLPToken is ERC4626Upgradeable {
         }
         _burn(owner, shares);
         lpToken.transfer(receiver, assets);
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
     }
 
     /**
@@ -103,6 +107,7 @@ contract WLPToken is ERC4626Upgradeable {
         }
         _burn(owner, shares);
         lpToken.transfer(receiver, assets);
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
     }
 
     /**

--- a/src/misc/ChainlinkCompositeOracleProvider.sol
+++ b/src/misc/ChainlinkCompositeOracleProvider.sol
@@ -67,7 +67,7 @@ contract ChainlinkCompositeOracleProvider {
      */
     constructor(AggregatorV3Interface _sequencerUptimeFeed, Config[] memory _configs) {
         for (uint256 i = 0; i < _configs.length; i++) {
-            if (i == 0 && address(_configs[i].feed) == address(0)) {
+            if (address(_configs[i].feed) == address(0)) {
                 revert InvalidFeed();
             }
 

--- a/src/misc/ChainlinkCompositeOracleProvider.sol
+++ b/src/misc/ChainlinkCompositeOracleProvider.sol
@@ -140,19 +140,15 @@ contract ChainlinkCompositeOracleProvider {
      * @return Decimals of the price
      */
     function decimals() external view returns (uint256) {
-        uint256 _decimals = 0;
+        if (configs.length == 0) return 0;
 
-        for (uint256 i = 0; i < configs.length; i++) {
-            Config memory config = configs[i];
-
-            if (address(config.feed) == address(0)) {
-                return _decimals;
-            }
-
-            _decimals = _getCurrentDecimals(config);
+        // last config only matters
+        Config memory lastConfig = configs[configs.length - 1];
+        if (address(lastConfig.feed) == address(0)) {
+            return lastConfig.isInverted ? lastConfig.assetDecimals : 0;
         }
 
-        return _decimals;
+        return _getCurrentDecimals(lastConfig);
     }
 
     /**

--- a/src/misc/ChainlinkCompositeOracleProvider.sol
+++ b/src/misc/ChainlinkCompositeOracleProvider.sol
@@ -79,7 +79,7 @@ contract ChainlinkCompositeOracleProvider {
                 revert InvalidFeed();
             }
 
-            if (address(_configs[i].feed) != address(0) && _configs[i].maxStalePeriod == 0) {
+            if (_configs[i].maxStalePeriod == 0) {
                 revert InvalidStalePeriod();
             }
 

--- a/src/misc/ChainlinkCompositeOracleProvider.sol
+++ b/src/misc/ChainlinkCompositeOracleProvider.sol
@@ -16,6 +16,11 @@ contract ChainlinkCompositeOracleProvider {
     }
 
     /**
+     * @notice Fixed-point precision for internal calculations
+     */
+    uint256 private constant PRECISION = 1e36;
+
+    /**
      * @notice Grace period time after the sequencer is back up
      */
     uint256 private constant GRACE_PERIOD_TIME = 3600;
@@ -82,21 +87,6 @@ contract ChainlinkCompositeOracleProvider {
     }
 
     /**
-     * @notice Get the current decimals of a config
-     * @param config The config to get decimals for
-     * @return The current decimals value
-     */
-    function _getCurrentDecimals(Config memory config) internal view returns (uint256) {
-        if (config.isInverted) return config.assetDecimals;
-        return config.feed.decimals();
-    }
-
-    /**
-     * @notice Fixed-point precision for internal calculations
-     */
-    uint256 private constant PRECISION = 1e36;
-
-    /**
      * @notice Get the price of the asset
      * @return Price of the asset
      */
@@ -158,6 +148,16 @@ contract ChainlinkCompositeOracleProvider {
         }
 
         return _getCurrentDecimals(lastConfig);
+    }
+
+    /**
+     * @notice Get the current decimals of a config
+     * @param config The config to get decimals for
+     * @return The current decimals value
+     */
+    function _getCurrentDecimals(Config memory config) internal view returns (uint256) {
+        if (config.isInverted) return config.assetDecimals;
+        return config.feed.decimals();
     }
 
     /**

--- a/src/periphery/Zap.sol
+++ b/src/periphery/Zap.sol
@@ -98,15 +98,14 @@ contract Zap is IZap, ReentrancyGuard {
         require(minAmountsOut.length == tokens.length, InvalidParameters());
 
         IERC20(wlp).safeTransferFrom(msg.sender, address(this), wlpAmount);
-
-        uint256 lpAmount = _redeem(wlp, wlpAmount, address(this));
+        _redeem(wlp, wlpAmount, address(this));
 
         address lpToken = _getPoolToken(spa);
-        uint256 lpTokenShares = ILPToken(lpToken).getSharesByPeggedToken(lpAmount);
-        IERC20(lpToken).forceApprove(spa, lpTokenShares);
+        uint256 lpAmount = ILPToken(lpToken).balanceOf(address(this));
+        IERC20(lpToken).forceApprove(spa, lpAmount);
 
-        if (proportional) amounts = _redeemProportion(spa, lpTokenShares, minAmountsOut);
-        else amounts = _redeemMulti(spa, minAmountsOut, lpTokenShares);
+        if (proportional) amounts = _redeemProportion(spa, lpAmount, minAmountsOut);
+        else amounts = _redeemMulti(spa, minAmountsOut, lpAmount);
 
         IERC20(lpToken).forceApprove(spa, 0);
         // repay remaining
@@ -148,13 +147,12 @@ contract Zap is IZap, ReentrancyGuard {
         require(tokenIndex < tokens.length, InvalidParameters());
 
         IERC20(wlp).safeTransferFrom(msg.sender, address(this), wlpAmount);
-
-        uint256 lpAmount = _redeem(wlp, wlpAmount, address(this));
+        _redeem(wlp, wlpAmount, address(this));
 
         address lpToken = _getPoolToken(spa);
-        uint256 lpTokenShares = ILPToken(lpToken).getSharesByPeggedToken(lpAmount);
-        IERC20(lpToken).forceApprove(spa, lpTokenShares);
-        amount = _redeemSingle(spa, lpTokenShares, tokenIndex, minAmountOut);
+        uint256 lpAmount = ILPToken(lpToken).balanceOf(address(this));
+        IERC20(lpToken).forceApprove(spa, lpAmount);
+        amount = _redeemSingle(spa, lpAmount, tokenIndex, minAmountOut);
 
         IERC20(lpToken).forceApprove(spa, 0);
         // repay remaining

--- a/test/ChainlinkCompositeOracle.t.sol
+++ b/test/ChainlinkCompositeOracle.t.sol
@@ -36,6 +36,6 @@ contract ChainlinkCompositeOracleProviderTest is Test {
         ChainlinkCompositeOracleProvider oracle =
             new ChainlinkCompositeOracleProvider(AggregatorV3Interface(address(0)), configs);
 
-        assertEq(oracle.price(), 1.065471935837571058e18);
+        assertEq(oracle.price(), 1.065471935837571059e18);
     }
 }

--- a/test/Factory.t.sol
+++ b/test/Factory.t.sol
@@ -56,6 +56,7 @@ contract FactoryTest is Test {
                 wlpTokenBeacon,
                 rampAControllerBeacon,
                 new ConstantExchangeRateProvider(),
+                0,
                 0
             )
         );
@@ -272,6 +273,7 @@ contract FactoryTest is Test {
             address(0),
             address(0),
             exchangeRateProvider,
+            0,
             0
         );
 

--- a/test/SelfPeggingAsset.t.sol
+++ b/test/SelfPeggingAsset.t.sol
@@ -983,7 +983,7 @@ contract SelfPeggingAssetTest is Test {
         rETHExchangeRateProvider1.setExchangeRate(0.994e18);
         rETHExchangeRateProvider2.setExchangeRate(0.994e18);
 
-        vm.warp(block.timestamp + 12 seconds);
+        vm.warp(block.timestamp + 2 days);
 
         vm.startPrank(user2);
         wstETH1.approve(address(_pool1), wstETHBalance1);

--- a/test/SelfPeggingAsset.t.sol
+++ b/test/SelfPeggingAsset.t.sol
@@ -862,6 +862,146 @@ contract SelfPeggingAssetTest is Test {
         assertGt(rETHBalance1, rETHBalance2);
     }
 
+    function test_ExchangeRateFeeSkipPeriod() external {
+        MockExchangeRateProvider rETHExchangeRateProvider1 = new MockExchangeRateProvider(1e18, 18);
+        MockExchangeRateProvider wstETHExchangeRateProvider1 = new MockExchangeRateProvider(1e18, 18);
+
+        MockExchangeRateProvider rETHExchangeRateProvider2 = new MockExchangeRateProvider(1e18, 18);
+        MockExchangeRateProvider wstETHExchangeRateProvider2 = new MockExchangeRateProvider(1e18, 18);
+
+        MockToken rETH1 = new MockToken("rETH", "rETH", 18);
+        MockToken wstETH1 = new MockToken("wstETH", "wstETH", 18);
+
+        MockToken rETH2 = new MockToken("rETH", "rETH", 18);
+        MockToken wstETH2 = new MockToken("wstETH", "wstETH", 18);
+
+        address[] memory _tokens1 = new address[](2);
+        _tokens1[0] = address(rETH1);
+        _tokens1[1] = address(wstETH1);
+
+        address[] memory _tokens2 = new address[](2);
+        _tokens2[0] = address(rETH2);
+        _tokens2[1] = address(wstETH2);
+
+        IExchangeRateProvider[] memory exchangeRateProviders1 = new IExchangeRateProvider[](2);
+        exchangeRateProviders1[0] = IExchangeRateProvider(rETHExchangeRateProvider1);
+        exchangeRateProviders1[1] = IExchangeRateProvider(wstETHExchangeRateProvider1);
+
+        IExchangeRateProvider[] memory exchangeRateProviders2 = new IExchangeRateProvider[](2);
+        exchangeRateProviders2[0] = IExchangeRateProvider(rETHExchangeRateProvider2);
+        exchangeRateProviders2[1] = IExchangeRateProvider(wstETHExchangeRateProvider2);
+
+        bytes memory data = abi.encodeCall(LPToken.initialize, ("LP Token", "LPT"));
+
+        ERC1967Proxy proxy1 = new ERC1967Proxy(address(new LPToken()), data);
+        LPToken _lpToken1 = LPToken(address(proxy1));
+        _lpToken1.transferOwnership(owner);
+
+        ERC1967Proxy proxy2 = new ERC1967Proxy(address(new LPToken()), data);
+        LPToken _lpToken2 = LPToken(address(proxy2));
+        _lpToken2.transferOwnership(owner);
+
+        uint256[] memory _fees = new uint256[](3);
+        _fees[0] = 0;
+        _fees[1] = 0.00001e10;
+        _fees[2] = 0;
+
+        uint256[] memory _precisions = new uint256[](2);
+        _precisions[0] = 1;
+        _precisions[1] = 1;
+
+        data = abi.encodeCall(
+            SelfPeggingAsset.initialize,
+            (_tokens1, _precisions, _fees, 0, _lpToken1, A, exchangeRateProviders1, address(0), 1e10)
+        );
+
+        proxy1 = new ERC1967Proxy(address(new SelfPeggingAsset()), data);
+        SelfPeggingAsset _pool1 = SelfPeggingAsset(address(proxy1));
+        _pool1.setRateChangeSkipPeriod(10 seconds);
+
+        _pool1.transferOwnership(owner);
+
+        data = abi.encodeCall(
+            SelfPeggingAsset.initialize,
+            (_tokens2, _precisions, _fees, 0, _lpToken2, A, exchangeRateProviders2, address(0), 1e10)
+        );
+
+        proxy2 = new ERC1967Proxy(address(new SelfPeggingAsset()), data);
+        SelfPeggingAsset _pool2 = SelfPeggingAsset(address(proxy2));
+
+        _pool2.transferOwnership(owner);
+
+        vm.startPrank(owner);
+        _lpToken1.addPool(address(_pool1));
+        _lpToken2.addPool(address(_pool2));
+        vm.stopPrank();
+
+        vm.prank(address(_pool1));
+        _lpToken1.addBuffer(100e18);
+
+        vm.prank(address(_pool2));
+        _lpToken2.addBuffer(100e18);
+
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 100e18;
+        amounts[1] = 100e18;
+
+        rETH1.mint(user, 100e18);
+        wstETH1.mint(user, 100e18);
+
+        rETH2.mint(user, 100e18);
+        wstETH2.mint(user, 100e18);
+
+        vm.startPrank(user);
+        rETH1.approve(address(_pool1), 100e18);
+        wstETH1.approve(address(_pool1), 100e18);
+
+        rETH2.approve(address(_pool2), 100e18);
+        wstETH2.approve(address(_pool2), 100e18);
+
+        _pool1.mint(amounts, 0);
+        _pool2.mint(amounts, 0);
+        vm.stopPrank();
+
+        rETH1.mint(user2, 1e18);
+        rETH2.mint(user2, 1e18);
+
+        vm.startPrank(user2);
+        rETH1.approve(address(_pool1), 1e18);
+        rETH2.approve(address(_pool2), 1e18);
+
+        _pool1.swap(0, 1, 1e18, 0);
+        _pool2.swap(0, 1, 1e18, 0);
+        vm.stopPrank();
+
+        uint256 wstETHBalance1 = wstETH1.balanceOf(user2);
+        uint256 wstETHBalance2 = wstETH2.balanceOf(user2);
+
+        assertLt(wstETHBalance1, 1e18);
+        assertLt(wstETHBalance2, 1e18);
+
+        rETHExchangeRateProvider1.setExchangeRate(0.994e18);
+        rETHExchangeRateProvider2.setExchangeRate(0.994e18);
+
+        vm.warp(block.timestamp + 12 seconds);
+
+        vm.startPrank(user2);
+        wstETH1.approve(address(_pool1), wstETHBalance1);
+
+        wstETH2.mint(user2, 1);
+        wstETH2.approve(address(_pool2), wstETHBalance2 + 1);
+
+        _pool1.swap(1, 0, wstETHBalance1, 0);
+        _pool2.swap(1, 0, 1, 0);
+        _pool2.swap(1, 0, wstETHBalance2, 0);
+        vm.stopPrank();
+
+        uint256 rETHBalance1 = rETH1.balanceOf(user2);
+        uint256 rETHBalance2 = rETH2.balanceOf(user2);
+
+        assertGt(rETHBalance1, rETHBalance2);
+    }
+
     function testFuzz_ExchangeRateFee(
         uint256 initialLiquidity,
         uint256 swapAmount,
@@ -926,6 +1066,7 @@ contract SelfPeggingAssetTest is Test {
         );
         proxy1 = new ERC1967Proxy(address(new SelfPeggingAsset()), data);
         SelfPeggingAsset pool1 = SelfPeggingAsset(address(proxy1));
+        pool1.setRateChangeSkipPeriod(100 days);
         pool1.transferOwnership(owner);
 
         data = abi.encodeCall(
@@ -934,6 +1075,7 @@ contract SelfPeggingAssetTest is Test {
         );
         proxy2 = new ERC1967Proxy(address(new SelfPeggingAsset()), data);
         SelfPeggingAsset pool2 = SelfPeggingAsset(address(proxy2));
+        pool2.setRateChangeSkipPeriod(100 days);
         pool2.transferOwnership(owner);
 
         vm.startPrank(owner);


### PR DESCRIPTION
- [x] fix(m7): `Zap.zapOut` Uses LP shares Instead of Tokens
- [x] fix(l13): missing zero check for every feed
- [x] fix(l14): add querying feed decimals on each call
- [x] fix(l15): simplify decimals() implementation
- [x] fix(l16): add high-precision accumulator for inverted price feeds
- [x] fix(l17): Volatility Fee Ratio Calculated from The Wrong Denominator
- [x] fix(l18): First Trader After Idle Period Pays Accumulated Volatility Fees