### PR TITLE
 Keeper Range Handling and Add Off-Peg Multiplier Validation

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,61 +1,60 @@
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
 [profile.default]
-  auto_detect_solc = false
-  block_timestamp = 1_680_220_800 # March 31, 2023 at 00:00 GMT
-  bytecode_hash = "none"
-  evm_version = "shanghai"
-  fuzz = { runs = 1_000 }
-  gas_reports = ["*"]
-  optimizer = true
-  optimizer_runs = 200
-  out = "out"
-  script = "script"
-  solc = "0.8.28"
-  src = "src"
-  test = "test"
-  remappings = [
-    "@chainlink/contracts/=node_modules/@chainlink/contracts/src/v0.8/",
-    "@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/",
-    "@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/",
-    "forge-std/=node_modules/forge-std/src/",
-  ]
-  fs_permissions = [{ access = "read-write", path = "./"}]
-  via_ir = true
+auto_detect_solc = false
+block_timestamp = 1_680_220_800 # March 31, 2023 at 00:00 GMT
+bytecode_hash = "none"
+evm_version = "shanghai"
+fuzz = { runs = 10_000 }
+gas_reports = ["*"]
+optimizer = true
+optimizer_runs = 200
+out = "out"
+script = "script"
+solc = "0.8.28"
+src = "src"
+test = "test"
+remappings = [
+  "@chainlink/contracts/=node_modules/@chainlink/contracts/src/v0.8/",
+  "@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/",
+  "@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/",
+  "forge-std/=node_modules/forge-std/src/",
+]
+fs_permissions = [{ access = "read-write", path = "./" }]
+via_ir = true
 
 [profile.ci]
-  fuzz = { runs = 10_000 }
-  verbosity = 4
+fuzz = { runs = 10_000 }
+verbosity = 4
 
 [fmt]
-  bracket_spacing = true
-  int_types = "long"
-  line_length = 120
-  multiline_func_header = "all"
-  number_underscore = "thousands"
-  quote_style = "double"
-  tab_width = 4
-  wrap_comments = true
-  single_line_statement_blocks = "preserve"
+bracket_spacing = true
+int_types = "long"
+line_length = 120
+multiline_func_header = "all"
+number_underscore = "thousands"
+quote_style = "double"
+tab_width = 4
+wrap_comments = true
+single_line_statement_blocks = "preserve"
 
 [rpc_endpoints]
-  arbitrum = "https://arb1.arbitrum.io/rpc"
-  base = "https://mainnet.base.org"
-  mainnet = "https://ethereum.blockpi.network/v1/rpc/public"
-  optimism = "https://mainnet.optimism.io"
-  sepolia = "https://ethereum-sepolia.blockpi.network/v1/rpc/public"
-  basesepolia = "https://sepolia.base.org"
-  arbitrumsepolia = "https://sepolia-rollup.arbitrum.io/rpc"
-  opsepolia = "https://sepolia.optimism.io"
-  monadtestnet = "https://testnet-rpc.monad.xyz"
-  bera-bepolia = "https://bepolia.rpc.berachain.com"
-  hyper-testnet = "https://rpc.hyperliquid-testnet.xyz/evm"
+arbitrum = "https://arb1.arbitrum.io/rpc"
+base = "https://mainnet.base.org"
+mainnet = "https://ethereum.blockpi.network/v1/rpc/public"
+optimism = "https://mainnet.optimism.io"
+sepolia = "https://ethereum-sepolia.blockpi.network/v1/rpc/public"
+basesepolia = "https://sepolia.base.org"
+arbitrumsepolia = "https://sepolia-rollup.arbitrum.io/rpc"
+opsepolia = "https://sepolia.optimism.io"
+monadtestnet = "https://testnet-rpc.monad.xyz"
+bera-bepolia = "https://bepolia.rpc.berachain.com"
+hyper-testnet = "https://rpc.hyperliquid-testnet.xyz/evm"
 
 [etherscan]
-  arbitrumsepolia =  { key = "${ETHERSCAN_ARBITRUM_KEY}", chain = 421614 }
-  basesepolia = { key = "${ETHERSCAN_BASE_KEY}", chain = 84532 }
-  opsepolia = { key = "${ETHERSCAN_OP_KEY}", chain = 11155420 }
-  arbitrum =  { key = "${ETHERSCAN_ARBITRUM_KEY}", chain = 42161 }
-  base = { key = "${ETHERSCAN_BASE_KEY}", chain = 8453 }
-  optimism = { key = "${ETHERSCAN_OP_KEY}", chain = 10 }
-  
+arbitrumsepolia = { key = "${ETHERSCAN_ARBITRUM_KEY}", chain = 421614 }
+basesepolia = { key = "${ETHERSCAN_BASE_KEY}", chain = 84532 }
+opsepolia = { key = "${ETHERSCAN_OP_KEY}", chain = 11155420 }
+arbitrum = { key = "${ETHERSCAN_ARBITRUM_KEY}", chain = 42161 }
+base = { key = "${ETHERSCAN_BASE_KEY}", chain = 8453 }
+optimism = { key = "${ETHERSCAN_OP_KEY}", chain = 10 }

--- a/script/Config.sol
+++ b/script/Config.sol
@@ -21,7 +21,7 @@ contract Config is Script {
     address lpTokenBeacon;
     address wlpTokenBeacon;
     address rampAControllerBeacon;
-    address keeperBeacon;
+    address keeperImplementation;
     address parameterRegistryBeacon;
     address zap;
 

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -26,7 +26,7 @@ contract Deploy is Config {
         address lpTokenImplentation = address(new LPToken());
         address wlpTokenImplentation = address(new WLPToken());
         address rampAControllerImplentation = address(new RampAController());
-        address keeperImplentation = address(new Keeper());
+        keeperImplementation = address(new Keeper());
 
         UpgradeableBeacon beacon = new UpgradeableBeacon(selfPeggingAssetImplentation, GOVERNOR);
         selfPeggingAssetBeacon = address(beacon);
@@ -39,9 +39,6 @@ contract Deploy is Config {
 
         beacon = new UpgradeableBeacon(rampAControllerImplentation, GOVERNOR);
         rampAControllerBeacon = address(beacon);
-
-        beacon = new UpgradeableBeacon(keeperImplentation, GOVERNOR);
-        keeperBeacon = address(beacon);
     }
 
     function deployFactory() internal {
@@ -64,7 +61,8 @@ contract Deploy is Config {
                 lpTokenBeacon,
                 wlpTokenBeacon,
                 rampAControllerBeacon,
-                new ConstantExchangeRateProvider(),
+                keeperImplementation,
+                address(new ConstantExchangeRateProvider()),
                 0,
                 0
             )

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -46,27 +46,26 @@ contract Deploy is Config {
         console.log("deploy-factory-logs");
         console.log("---------------");
 
-        bytes memory data = abi.encodeCall(
-            SelfPeggingAssetFactory.initialize,
-            (
-                GOVERNOR,
-                GOVERNOR,
-                0,
-                0,
-                0,
-                0,
-                100,
-                30 minutes,
-                selfPeggingAssetBeacon,
-                lpTokenBeacon,
-                wlpTokenBeacon,
-                rampAControllerBeacon,
-                keeperImplementation,
-                address(new ConstantExchangeRateProvider()),
-                0,
-                0
-            )
+        SelfPeggingAssetFactory.InitializeArgument memory args = SelfPeggingAssetFactory.InitializeArgument(
+            GOVERNOR,
+            GOVERNOR,
+            0,
+            0,
+            0,
+            0,
+            100,
+            30 minutes,
+            selfPeggingAssetBeacon,
+            lpTokenBeacon,
+            wlpTokenBeacon,
+            rampAControllerBeacon,
+            keeperImplementation,
+            address(new ConstantExchangeRateProvider()),
+            0,
+            0
         );
+
+        bytes memory data = abi.encodeCall(SelfPeggingAssetFactory.initialize, (args));
         ERC1967Proxy proxy = new ERC1967Proxy(address(new SelfPeggingAssetFactory()), data);
 
         factory = SelfPeggingAssetFactory(address(proxy));

--- a/src/SelfPeggingAssetFactory.sol
+++ b/src/SelfPeggingAssetFactory.sol
@@ -35,6 +35,26 @@ contract SelfPeggingAssetFactory is UUPSUpgradeable, OwnableUpgradeable {
         ERC4626
     }
 
+    /// @notice Parameters for initailizing the factory
+    struct InitializeArgument {
+        address owner;
+        address governor;
+        uint256 mintFee;
+        uint256 swapFee;
+        uint256 redeemFee;
+        uint256 offPegFeeMultiplier;
+        uint256 A;
+        uint256 minRampTime;
+        address selfPeggingAssetBeacon;
+        address lpTokenBeacon;
+        address wlpTokenBeacon;
+        address rampAControllerBeacon;
+        address keeperImplementation;
+        address constantExchangeRateProvider;
+        uint256 exchangeRateFeeFactor;
+        uint256 bufferPercent;
+    }
+
     /// @notice Parameters for creating a new pool
     struct CreatePoolArgument {
         /// @notice Address of token A
@@ -228,57 +248,37 @@ contract SelfPeggingAssetFactory is UUPSUpgradeable, OwnableUpgradeable {
     /**
      * @dev Initializes the StableSwap Application contract.
      */
-    function initialize(
-        address _owner,
-        address _governor,
-        uint256 _mintFee,
-        uint256 _swapFee,
-        uint256 _redeemFee,
-        uint256 _offPegFeeMultiplier,
-        uint256 _A,
-        uint256 _minRampTime,
-        address _selfPeggingAssetBeacon,
-        address _lpTokenBeacon,
-        address _wlpTokenBeacon,
-        address _rampAControllerBeacon,
-        address _keeperImplementation,
-        address _constantExchangeRateProvider,
-        uint256 _exchangeRateFeeFactor,
-        uint256 _bufferPercent
-    )
-        public
-        initializer
-    {
-        require(_owner != address(0), InvalidAddress());
-        require(_governor != address(0), InvalidAddress());
-        require(_A > 0, InvalidValue());
-        require(_selfPeggingAssetBeacon != address(0), InvalidAddress());
-        require(_lpTokenBeacon != address(0), InvalidAddress());
-        require(_wlpTokenBeacon != address(0), InvalidAddress());
-        require(_keeperImplementation != address(0), InvalidAddress());
-        require(_constantExchangeRateProvider != address(0), InvalidAddress());
-        require(_rampAControllerBeacon != address(0), InvalidAddress());
+    function initialize(InitializeArgument memory argument) public initializer {
+        require(argument.owner != address(0), InvalidAddress());
+        require(argument.governor != address(0), InvalidAddress());
+        require(argument.A > 0, InvalidValue());
+        require(argument.selfPeggingAssetBeacon != address(0), InvalidAddress());
+        require(argument.lpTokenBeacon != address(0), InvalidAddress());
+        require(argument.wlpTokenBeacon != address(0), InvalidAddress());
+        require(argument.keeperImplementation != address(0), InvalidAddress());
+        require(argument.constantExchangeRateProvider != address(0), InvalidAddress());
+        require(argument.rampAControllerBeacon != address(0), InvalidAddress());
 
-        __Ownable_init(_owner);
+        __Ownable_init(argument.owner);
         __UUPSUpgradeable_init();
 
-        governor = _governor;
+        governor = argument.governor;
 
-        selfPeggingAssetBeacon = _selfPeggingAssetBeacon;
-        lpTokenBeacon = _lpTokenBeacon;
-        wlpTokenBeacon = _wlpTokenBeacon;
-        rampAControllerBeacon = _rampAControllerBeacon;
-        keeperImplementation = _keeperImplementation;
-        constantExchangeRateProvider = _constantExchangeRateProvider;
+        selfPeggingAssetBeacon = argument.selfPeggingAssetBeacon;
+        lpTokenBeacon = argument.lpTokenBeacon;
+        wlpTokenBeacon = argument.wlpTokenBeacon;
+        rampAControllerBeacon = argument.rampAControllerBeacon;
+        keeperImplementation = argument.keeperImplementation;
+        constantExchangeRateProvider = argument.constantExchangeRateProvider;
 
-        mintFee = _mintFee;
-        swapFee = _swapFee;
-        redeemFee = _redeemFee;
-        A = _A;
-        offPegFeeMultiplier = _offPegFeeMultiplier;
-        minRampTime = _minRampTime;
-        exchangeRateFeeFactor = _exchangeRateFeeFactor;
-        bufferPercent = _bufferPercent;
+        mintFee = argument.mintFee;
+        swapFee = argument.swapFee;
+        redeemFee = argument.redeemFee;
+        A = argument.A;
+        offPegFeeMultiplier = argument.offPegFeeMultiplier;
+        minRampTime = argument.minRampTime;
+        exchangeRateFeeFactor = argument.exchangeRateFeeFactor;
+        bufferPercent = argument.bufferPercent;
     }
 
     /**

--- a/src/SelfPeggingAssetFactory.sol
+++ b/src/SelfPeggingAssetFactory.sol
@@ -408,15 +408,6 @@ contract SelfPeggingAssetFactory is UUPSUpgradeable, OwnableUpgradeable {
         ParameterRegistry parameterRegistry = new ParameterRegistry(governor, address(selfPeggingAssetProxy));
 
         Keeper keeper = Keeper(address(keeperProxy));
-        keeper.initialize(
-            address(owner()),
-            address(governor),
-            address(governor),
-            address(governor),
-            IParameterRegistry(address(parameterRegistry)),
-            IRampAController(address(rampAControllerProxy)),
-            SelfPeggingAsset(address(selfPeggingAssetProxy))
-        );
 
         SelfPeggingAsset selfPeggingAsset = SelfPeggingAsset(address(selfPeggingAssetProxy));
         selfPeggingAsset.initialize(
@@ -436,6 +427,16 @@ contract SelfPeggingAssetFactory is UUPSUpgradeable, OwnableUpgradeable {
         string memory name = string.concat(string.concat(string.concat("Self Pegging Asset ", symbolA), " "), symbolB);
 
         LPToken lpToken = LPToken(address(lpTokenProxy));
+        keeper.initialize(
+            address(owner()),
+            address(governor),
+            address(governor),
+            address(governor),
+            IParameterRegistry(address(parameterRegistry)),
+            IRampAController(address(rampAControllerProxy)),
+            SelfPeggingAsset(address(selfPeggingAssetProxy)),
+            lpToken
+        );
         lpToken.initialize(name, symbol, bufferPercent, address(keeperProxy), address(selfPeggingAsset));
 
         bytes memory wlpTokenInit = abi.encodeCall(WLPToken.initialize, (ILPToken(lpToken)));

--- a/src/interfaces/IKeeper.sol
+++ b/src/interfaces/IKeeper.sol
@@ -11,6 +11,24 @@ import "../LPToken.sol";
  * @notice Interface for the Keeper contract that enforces parameter bounds for curators
  */
 interface IKeeper {
+    // self-descripting events for gov actions
+    event RampAInitiated(address indexed caller, uint256 oldA, uint256 newA, uint256 endTime);
+    event MinRampTimeUpdated(address indexed caller, uint256 oldTime, uint256 newTime);
+    event SwapFeeUpdated(address indexed caller, uint256 oldFee, uint256 newFee);
+    event MintFeeUpdated(address indexed caller, uint256 oldFee, uint256 newFee);
+    event RedeemFeeUpdated(address indexed caller, uint256 oldFee, uint256 newFee);
+    event OffPegFeeMultiplierUpdated(address indexed caller, uint256 oldMultiplier, uint256 newMultiplier);
+    event ExchangeRateFeeFactorUpdated(address indexed caller, uint256 oldFactor, uint256 newFactor);
+    event BufferPercentUpdated(address indexed caller, uint256 oldBuffer, uint256 newBuffer);
+    event DecayPeriodUpdated(address indexed caller, uint256 oldPeriod, uint256 newPeriod);
+    event RateChangeSkipPeriodUpdated(address indexed caller, uint256 oldPeriod, uint256 newPeriod);
+    event FeeErrorMarginUpdated(address indexed caller, uint256 oldMargin, uint256 newMargin);
+    event YieldErrorMarginUpdated(address indexed caller, uint256 oldMargin, uint256 newMargin);
+    event LossDistributed(address indexed caller);
+    event ProtocolPaused(address indexed caller);
+    event ProtocolUnpaused(address indexed caller);
+    event RampCancelled(address indexed caller);
+
     /**
      * @notice Allows curators to gradually ramp the A coefficient within allowed bounds
      * @param newA The target A value

--- a/src/interfaces/IKeeper.sol
+++ b/src/interfaces/IKeeper.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 import "../interfaces/IRampAController.sol";
 import "../SelfPeggingAsset.sol";
 import "./IParameterRegistry.sol";
+import "../LPToken.sol";
 
 /**
  * @title IKeeper
@@ -52,6 +53,12 @@ interface IKeeper {
      * @param newFeeFactor The new exchange rate fee value
      */
     function setExchangeRateFeeFactor(uint256 newFeeFactor) external;
+
+    /**
+     * @notice Set the buffer within allowed bounds
+     * @param newBuffer The new buffer value
+     */
+    function setBufferPercent(uint256 newBuffer) external;
 
     /**
      * @notice Set the decay period
@@ -114,4 +121,10 @@ interface IKeeper {
      * @return The SelfPeggingAsset address
      */
     function getSpa() external view returns (SelfPeggingAsset);
+
+    /**
+     * @notice Get the LPToken being managed
+     * @return The LPToken address
+     */
+    function getLpToken() external view returns (LPToken);
 }

--- a/src/interfaces/IKeeper.sol
+++ b/src/interfaces/IKeeper.sol
@@ -12,22 +12,22 @@ import "../LPToken.sol";
  */
 interface IKeeper {
     // self-descripting events for gov actions
-    event RampAInitiated(address indexed caller, uint256 oldA, uint256 newA, uint256 endTime);
-    event MinRampTimeUpdated(address indexed caller, uint256 oldTime, uint256 newTime);
-    event SwapFeeUpdated(address indexed caller, uint256 oldFee, uint256 newFee);
-    event MintFeeUpdated(address indexed caller, uint256 oldFee, uint256 newFee);
-    event RedeemFeeUpdated(address indexed caller, uint256 oldFee, uint256 newFee);
-    event OffPegFeeMultiplierUpdated(address indexed caller, uint256 oldMultiplier, uint256 newMultiplier);
-    event ExchangeRateFeeFactorUpdated(address indexed caller, uint256 oldFactor, uint256 newFactor);
-    event BufferPercentUpdated(address indexed caller, uint256 oldBuffer, uint256 newBuffer);
-    event DecayPeriodUpdated(address indexed caller, uint256 oldPeriod, uint256 newPeriod);
-    event RateChangeSkipPeriodUpdated(address indexed caller, uint256 oldPeriod, uint256 newPeriod);
-    event FeeErrorMarginUpdated(address indexed caller, uint256 oldMargin, uint256 newMargin);
-    event YieldErrorMarginUpdated(address indexed caller, uint256 oldMargin, uint256 newMargin);
-    event LossDistributed(address indexed caller);
-    event ProtocolPaused(address indexed caller);
-    event ProtocolUnpaused(address indexed caller);
-    event RampCancelled(address indexed caller);
+    event RampAInitiated(uint256 oldA, uint256 newA, uint256 endTime);
+    event MinRampTimeUpdated(uint256 oldTime, uint256 newTime);
+    event SwapFeeUpdated(uint256 oldFee, uint256 newFee);
+    event MintFeeUpdated(uint256 oldFee, uint256 newFee);
+    event RedeemFeeUpdated(uint256 oldFee, uint256 newFee);
+    event OffPegFeeMultiplierUpdated(uint256 oldMultiplier, uint256 newMultiplier);
+    event ExchangeRateFeeFactorUpdated(uint256 oldFactor, uint256 newFactor);
+    event BufferPercentUpdated(uint256 oldBuffer, uint256 newBuffer);
+    event DecayPeriodUpdated(uint256 oldPeriod, uint256 newPeriod);
+    event RateChangeSkipPeriodUpdated(uint256 oldPeriod, uint256 newPeriod);
+    event FeeErrorMarginUpdated(uint256 oldMargin, uint256 newMargin);
+    event YieldErrorMarginUpdated(uint256 oldMargin, uint256 newMargin);
+    event LossDistributed();
+    event ProtocolPaused();
+    event ProtocolUnpaused();
+    event RampCancelled();
 
     /**
      * @notice Allows curators to gradually ramp the A coefficient within allowed bounds

--- a/src/interfaces/IParameterRegistry.sol
+++ b/src/interfaces/IParameterRegistry.sol
@@ -19,7 +19,8 @@ interface IParameterRegistry {
         RateChangeSkipPeriod,
         FeeErrorMargin,
         YieldErrorMargin,
-        MinRampTime
+        MinRampTime,
+        BufferPercent
     }
 
     /**
@@ -88,4 +89,7 @@ interface IParameterRegistry {
 
     /// @return Bounds for the minimum ramp time
     function minRampTimeParams() external view returns (Bounds memory);
+
+    /// @return Bounds for the buffer percentage
+    function bufferPercentParams() external view returns (Bounds memory);
 }

--- a/src/interfaces/IParameterRegistry.sol
+++ b/src/interfaces/IParameterRegistry.sol
@@ -25,14 +25,16 @@ interface IParameterRegistry {
     /**
      * @notice Structure representing bounds for a given parameter.
      * @dev All percentages are expressed in parts-per-million (ppm), i.e., 1e6 = 100%.
-     * @param max The hard cap for the parameter value.
-     * @param maxDecreasePct The maximum decrease allowed per transaction, e.g., 900_000 = -90%.
-     * @param maxIncreasePct The maximum increase allowed per transaction, e.g., 900_000 = +90%.
+     * @param max The maximum hard cap for the parameter value in parameter format.
+     * @param min The minimum hard cap for the parameter value in parameter format.
+     * @param maxDecreasePct The maximum decrease allowed per transaction with 1e10 decimal, e.g., 9e9 = -90%.
+     * @param maxIncreasePct The maximum increase allowed per transaction with 1e10 decimal, e.g., 9e9 = +90%.
      */
     struct Bounds {
         uint256 max;
-        uint32 maxDecreasePct;
-        uint32 maxIncreasePct;
+        uint256 min;
+        uint64 maxDecreasePct;
+        uint64 maxIncreasePct;
     }
 
     /**

--- a/src/interfaces/IParameterRegistry.sol
+++ b/src/interfaces/IParameterRegistry.sol
@@ -40,12 +40,11 @@ interface IParameterRegistry {
 
     /**
      * @notice Emitted when parameter bounds are updated.
-     * @param caller The address of governor that performed the update.
      * @param key The parameter key that was updated.
      * @param oldParams The old bounds before the update.
      * @param newParams The new bounds after the update.
      */
-    event BoundsUpdated(address indexed caller, ParamKey key, Bounds oldParams, Bounds newParams);
+    event BoundsUpdated(ParamKey key, Bounds oldParams, Bounds newParams);
 
     error ZeroAddress();
 

--- a/src/periphery/Keeper.sol
+++ b/src/periphery/Keeper.sol
@@ -101,7 +101,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkBounds(newA, curA, aParams);
 
         rampAController.rampA(newA, endTime);
-        emit RampAInitiated(msg.sender, curA, newA, endTime);
+        emit RampAInitiated(curA, newA, endTime);
     }
 
     /**
@@ -114,7 +114,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkBounds(newMinRampTime, curMinRampTime, minRampTimeParams);
 
         rampAController.setMinRampTime(newMinRampTime);
-        emit MinRampTimeUpdated(msg.sender, curMinRampTime, newMinRampTime);
+        emit MinRampTimeUpdated(curMinRampTime, newMinRampTime);
     }
 
     /**
@@ -127,7 +127,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkBounds(newFee, cur, swapFeeParams);
 
         spa.setSwapFee(newFee);
-        emit SwapFeeUpdated(msg.sender, cur, newFee);
+        emit SwapFeeUpdated(cur, newFee);
     }
 
     /**
@@ -140,7 +140,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkBounds(newFee, cur, mintFeeParams);
 
         spa.setMintFee(newFee);
-        emit MintFeeUpdated(msg.sender, cur, newFee);
+        emit MintFeeUpdated(cur, newFee);
     }
 
     /**
@@ -153,7 +153,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkBounds(newFee, cur, redeemFeeParams);
 
         spa.setRedeemFee(newFee);
-        emit RedeemFeeUpdated(msg.sender, cur, newFee);
+        emit RedeemFeeUpdated(cur, newFee);
     }
 
     /**
@@ -161,7 +161,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
      */
     function cancelRamp() external override onlyRole(GUARDIAN_ROLE) {
         rampAController.stopRamp();
-        emit RampCancelled(msg.sender);
+        emit RampCancelled();
     }
 
     /**
@@ -174,7 +174,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkBounds(newMultiplier, cur, offPegParams);
 
         spa.setOffPegFeeMultiplier(newMultiplier);
-        emit OffPegFeeMultiplierUpdated(msg.sender, cur, newMultiplier);
+        emit OffPegFeeMultiplierUpdated(cur, newMultiplier);
     }
 
     /**
@@ -187,7 +187,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkBounds(newFeeFactor, cur, exchangeRateFeeParams);
 
         spa.setExchangeRateFeeFactor(newFeeFactor);
-        emit ExchangeRateFeeFactorUpdated(msg.sender, cur, newFeeFactor);
+        emit ExchangeRateFeeFactorUpdated(cur, newFeeFactor);
     }
 
     /**
@@ -200,7 +200,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkBounds(newBuffer, cur, bufferParams);
 
         lpToken.setBuffer(newBuffer);
-        emit BufferPercentUpdated(msg.sender, cur, newBuffer);
+        emit BufferPercentUpdated(cur, newBuffer);
     }
 
     /**
@@ -213,7 +213,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkBounds(newDecayPeriod, cur, decayPeriodParams);
 
         spa.setDecayPeriod(newDecayPeriod);
-        emit DecayPeriodUpdated(msg.sender, cur, newDecayPeriod);
+        emit DecayPeriodUpdated(cur, newDecayPeriod);
     }
 
     /**
@@ -226,7 +226,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkBounds(newSkipPeriod, cur, rateChangeSkipPeriodParams);
 
         spa.setRateChangeSkipPeriod(newSkipPeriod);
-        emit RateChangeSkipPeriodUpdated(msg.sender, cur, newSkipPeriod);
+        emit RateChangeSkipPeriodUpdated(cur, newSkipPeriod);
     }
 
     /**
@@ -239,7 +239,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkBounds(newMargin, cur, feeErrorMarginParams);
 
         spa.updateFeeErrorMargin(newMargin);
-        emit FeeErrorMarginUpdated(msg.sender, cur, newMargin);
+        emit FeeErrorMarginUpdated(cur, newMargin);
     }
 
     /**
@@ -252,7 +252,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkBounds(newMargin, cur, yieldErrorMarginParams);
 
         spa.updateYieldErrorMargin(newMargin);
-        emit YieldErrorMarginUpdated(msg.sender, cur, newMargin);
+        emit YieldErrorMarginUpdated(cur, newMargin);
     }
 
     /**
@@ -260,7 +260,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
      */
     function distributeLoss() external override onlyRole(GOVERNOR_ROLE) {
         spa.distributeLoss();
-        emit LossDistributed(msg.sender);
+        emit LossDistributed();
     }
 
     /**
@@ -268,7 +268,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
      */
     function pause() external override onlyRole(GUARDIAN_ROLE) {
         spa.pause();
-        emit ProtocolPaused(msg.sender);
+        emit ProtocolPaused();
     }
 
     /**
@@ -276,7 +276,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
      */
     function unpause() external override onlyRole(PROTOCOL_OWNER_ROLE) {
         spa.unpause();
-        emit ProtocolUnpaused(msg.sender);
+        emit ProtocolUnpaused();
     }
 
     /**

--- a/src/periphery/Keeper.sol
+++ b/src/periphery/Keeper.sol
@@ -101,6 +101,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         require(newA <= aParams.max, OutOfBounds());
 
         rampAController.rampA(newA, endTime);
+        emit RampAInitiated(msg.sender, curA, newA, endTime);
     }
 
     /**
@@ -113,6 +114,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkRange(newMinRampTime, curMinRampTime, minRampTimeParams);
 
         rampAController.setMinRampTime(newMinRampTime);
+        emit MinRampTimeUpdated(msg.sender, curMinRampTime, newMinRampTime);
     }
 
     /**
@@ -125,6 +127,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkRange(newFee, cur, swapFeeParams);
 
         spa.setSwapFee(newFee);
+        emit SwapFeeUpdated(msg.sender, cur, newFee);
     }
 
     /**
@@ -137,6 +140,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkRange(newFee, cur, mintFeeParams);
 
         spa.setMintFee(newFee);
+        emit MintFeeUpdated(msg.sender, cur, newFee);
     }
 
     /**
@@ -149,6 +153,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
 
         checkRange(newFee, cur, redeemFeeParams);
         spa.setRedeemFee(newFee);
+        emit RedeemFeeUpdated(msg.sender, cur, newFee);
     }
 
     /**
@@ -156,6 +161,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
      */
     function cancelRamp() external override onlyRole(GUARDIAN_ROLE) {
         rampAController.stopRamp();
+        emit RampCancelled(msg.sender);
     }
 
     /**
@@ -170,6 +176,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         require(newMultiplier >= offPegParams.min, OutOfBounds());
 
         spa.setOffPegFeeMultiplier(newMultiplier);
+        emit OffPegFeeMultiplierUpdated(msg.sender, cur, newMultiplier);
     }
 
     /**
@@ -182,6 +189,8 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkRange(newFeeFactor, cur, exchangeRateFeeParams);
 
         spa.setExchangeRateFeeFactor(newFeeFactor);
+        emit ExchangeRateFeeFactorUpdated(msg.sender, cur, newFeeFactor);
+    }
 
     /**
      * @inheritdoc IKeeper
@@ -206,6 +215,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkRange(newDecayPeriod, cur, decayPeriodParams);
 
         spa.setDecayPeriod(newDecayPeriod);
+        emit DecayPeriodUpdated(msg.sender, cur, newDecayPeriod);
     }
 
     /**
@@ -218,6 +228,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkRange(newSkipPeriod, cur, rateChangeSkipPeriodParams);
 
         spa.setRateChangeSkipPeriod(newSkipPeriod);
+        emit RateChangeSkipPeriodUpdated(msg.sender, cur, newSkipPeriod);
     }
 
     /**
@@ -230,6 +241,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkRange(newMargin, cur, feeErrorMarginParams);
 
         spa.updateFeeErrorMargin(newMargin);
+        emit FeeErrorMarginUpdated(msg.sender, cur, newMargin);
     }
 
     /**
@@ -242,6 +254,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
         checkRange(newMargin, cur, yieldErrorMarginParams);
 
         spa.updateYieldErrorMargin(newMargin);
+        emit YieldErrorMarginUpdated(msg.sender, cur, newMargin);
     }
 
     /**
@@ -249,6 +262,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
      */
     function distributeLoss() external override onlyRole(GOVERNOR_ROLE) {
         spa.distributeLoss();
+        emit LossDistributed(msg.sender);
     }
 
     /**
@@ -256,6 +270,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
      */
     function pause() external override onlyRole(GUARDIAN_ROLE) {
         spa.pause();
+        emit ProtocolPaused(msg.sender);
     }
 
     /**
@@ -263,6 +278,7 @@ contract Keeper is AccessControlUpgradeable, UUPSUpgradeable, IKeeper {
      */
     function unpause() external override onlyRole(PROTOCOL_OWNER_ROLE) {
         spa.unpause();
+        emit ProtocolUnpaused(msg.sender);
     }
 
     /**

--- a/src/periphery/ParameterRegistry.sol
+++ b/src/periphery/ParameterRegistry.sol
@@ -120,4 +120,11 @@ contract ParameterRegistry is IParameterRegistry, Ownable {
     function minRampTimeParams() external view returns (Bounds memory) {
         return bounds[ParamKey.MinRampTime];
     }
+
+    /**
+     * @inheritdoc IParameterRegistry
+     */
+    function bufferPercentParams() external view returns (Bounds memory) {
+        return bounds[ParamKey.BufferPercent];
+    }
 }

--- a/src/periphery/ParameterRegistry.sol
+++ b/src/periphery/ParameterRegistry.sol
@@ -12,9 +12,11 @@ import "../SelfPeggingAsset.sol";
  * Each SPA has its own ParameterRegistry
  */
 contract ParameterRegistry is IParameterRegistry, Ownable {
+    uint256 private constant MIN_MULTIPLIER = 1e10; // min offpeg multiplier 1
+
     uint256 private constant MAX_A = 10 ** 6; // 1M
-    uint32 private constant MAX_DECREASE_PCT_A = 900_000; // -90%
-    uint32 private constant MAX_INCREASE_PCT_A = 9_000_000; // +900%
+    uint64 private constant MAX_DECREASE_PCT_A = 0.9e10; // -90%
+    uint64 private constant MAX_INCREASE_PCT_A = 9e10; // +900%
 
     /// @notice SPA this registry is connected
     SelfPeggingAsset public spa;
@@ -28,7 +30,10 @@ contract ParameterRegistry is IParameterRegistry, Ownable {
 
         // set default values for A boundry
         bounds[ParamKey.A] =
-            Bounds({ max: MAX_A, maxDecreasePct: MAX_DECREASE_PCT_A, maxIncreasePct: MAX_INCREASE_PCT_A });
+            Bounds({ max: MAX_A, min: 0, maxDecreasePct: MAX_DECREASE_PCT_A, maxIncreasePct: MAX_INCREASE_PCT_A });
+
+        // set default values for A boundry
+        bounds[ParamKey.OffPeg] = Bounds({ max: 0, min: MIN_MULTIPLIER, maxDecreasePct: 0, maxIncreasePct: 0 });
     }
 
     /**

--- a/src/periphery/ParameterRegistry.sol
+++ b/src/periphery/ParameterRegistry.sol
@@ -40,7 +40,7 @@ contract ParameterRegistry is IParameterRegistry, Ownable {
      * @inheritdoc IParameterRegistry
      */
     function setBounds(ParamKey key, Bounds calldata newBounds) external onlyOwner {
-        emit BoundsUpdated(msg.sender, key, bounds[key], newBounds);
+        emit BoundsUpdated(key, bounds[key], newBounds);
         bounds[key] = newBounds;
     }
 

--- a/test/Factory.t.sol
+++ b/test/Factory.t.sol
@@ -45,27 +45,26 @@ contract FactoryTest is Test {
         beacon = new UpgradeableBeacon(rampAControllerImplentation, governor);
         address rampAControllerBeacon = address(beacon);
 
-        bytes memory data = abi.encodeCall(
-            SelfPeggingAssetFactory.initialize,
-            (
-                governor,
-                governor,
-                0,
-                0,
-                0,
-                0,
-                100,
-                30 minutes,
-                selfPeggingAssetBeacon,
-                lpTokenBeacon,
-                wlpTokenBeacon,
-                rampAControllerBeacon,
-                keeperImplementation,
-                address(new ConstantExchangeRateProvider()),
-                0,
-                0
-            )
+        SelfPeggingAssetFactory.InitializeArgument memory args = SelfPeggingAssetFactory.InitializeArgument(
+            governor,
+            governor,
+            0,
+            0,
+            0,
+            0,
+            100,
+            30 minutes,
+            selfPeggingAssetBeacon,
+            lpTokenBeacon,
+            wlpTokenBeacon,
+            rampAControllerBeacon,
+            keeperImplementation,
+            address(new ConstantExchangeRateProvider()),
+            0,
+            0
         );
+
+        bytes memory data = abi.encodeCall(SelfPeggingAssetFactory.initialize, (args));
         ERC1967Proxy proxy = new ERC1967Proxy(address(new SelfPeggingAssetFactory()), data);
         factory = SelfPeggingAssetFactory(address(proxy));
     }
@@ -250,8 +249,7 @@ contract FactoryTest is Test {
         SelfPeggingAssetFactory factory = new SelfPeggingAssetFactory();
         ConstantExchangeRateProvider exchangeRateProvider = new ConstantExchangeRateProvider();
 
-        vm.expectRevert(Initializable.InvalidInitialization.selector);
-        factory.initialize(
+        SelfPeggingAssetFactory.InitializeArgument memory args = SelfPeggingAssetFactory.InitializeArgument(
             governor,
             governor,
             0,
@@ -269,6 +267,9 @@ contract FactoryTest is Test {
             0,
             0
         );
+
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        factory.initialize(args);
 
         SelfPeggingAsset selfPeggingAsset = new SelfPeggingAsset();
         address[] memory _tokens;

--- a/test/Factory.t.sol
+++ b/test/Factory.t.sol
@@ -31,7 +31,7 @@ contract FactoryTest is Test {
         address lpTokenImplentation = address(new LPToken());
         address wlpTokenImplentation = address(new WLPToken());
         address rampAControllerImplentation = address(new RampAController());
-        address keeperImplentation = address(new Keeper());
+        address keeperImplementation = address(new Keeper());
 
         UpgradeableBeacon beacon = new UpgradeableBeacon(selfPeggingAssetImplentation, governor);
         address selfPeggingAssetBeacon = address(beacon);
@@ -44,9 +44,6 @@ contract FactoryTest is Test {
 
         beacon = new UpgradeableBeacon(rampAControllerImplentation, governor);
         address rampAControllerBeacon = address(beacon);
-
-        beacon = new UpgradeableBeacon(keeperImplentation, governor);
-        address keeperBeacon = address(beacon);
 
         bytes memory data = abi.encodeCall(
             SelfPeggingAssetFactory.initialize,
@@ -63,7 +60,8 @@ contract FactoryTest is Test {
                 lpTokenBeacon,
                 wlpTokenBeacon,
                 rampAControllerBeacon,
-                new ConstantExchangeRateProvider(),
+                keeperImplementation,
+                address(new ConstantExchangeRateProvider()),
                 0,
                 0
             )
@@ -266,7 +264,8 @@ contract FactoryTest is Test {
             address(0),
             address(0),
             address(0),
-            exchangeRateProvider,
+            address(0),
+            address(exchangeRateProvider),
             0,
             0
         );

--- a/test/Factory.t.sol
+++ b/test/Factory.t.sol
@@ -167,30 +167,9 @@ contract FactoryTest is Test {
         factory.createPool(arg);
 
         Vm.Log[] memory entries = vm.getRecordedLogs();
-        bytes32 eventSig = keccak256("PoolCreated(address,address,address,address,address,address)");
 
-        address decodedPoolToken;
-        address decodedSelfPeggingAsset;
-        address decodedWrappedPoolToken;
-        address decodedRampAController;
-        address decodedKeeper;
-        address decodedParameterRegistry;
-
-        for (uint256 i = 0; i < entries.length; i++) {
-            Vm.Log memory log = entries[i];
-
-            if (log.topics[0] == eventSig) {
-                (
-                    decodedPoolToken,
-                    decodedSelfPeggingAsset,
-                    decodedWrappedPoolToken,
-                    decodedRampAController,
-                    decodedKeeper,
-                    decodedParameterRegistry
-                ) = abi.decode(log.data, (address, address, address, address, address, address));
-            }
-        }
-
+        (address decodedPoolToken, address decodedSelfPeggingAsset, address decodedWrappedPoolToken,,,) =
+            _decodePoolCreatedEvent(entries);
         SelfPeggingAsset selfPeggingAsset = SelfPeggingAsset(decodedSelfPeggingAsset);
         LPToken poolToken = LPToken(decodedPoolToken);
         WLPToken wrappedPoolToken = WLPToken(decodedWrappedPoolToken);
@@ -242,29 +221,9 @@ contract FactoryTest is Test {
         vm.recordLogs();
         factory.createPool(arg);
         Vm.Log[] memory entries = vm.getRecordedLogs();
-        bytes32 eventSig = keccak256("PoolCreated(address,address,address,address,address,address)");
 
-        address decodedPoolToken;
-        address decodedSelfPeggingAsset;
-        address decodedWrappedPoolToken;
-        address decodedRampAController;
-        address decodedKeeper;
-        address decodedParameterRegistry;
-
-        for (uint256 i = 0; i < entries.length; i++) {
-            Vm.Log memory log = entries[i];
-
-            if (log.topics[0] == eventSig) {
-                (
-                    decodedPoolToken,
-                    decodedSelfPeggingAsset,
-                    decodedWrappedPoolToken,
-                    decodedRampAController,
-                    decodedKeeper,
-                    decodedParameterRegistry
-                ) = abi.decode(log.data, (address, address, address, address, address, address));
-            }
-        }
+        (address decodedPoolToken, address decodedSelfPeggingAsset, address decodedWrappedPoolToken,,,) =
+            _decodePoolCreatedEvent(entries);
 
         SelfPeggingAsset selfPeggingAsset = SelfPeggingAsset(decodedSelfPeggingAsset);
         LPToken poolToken = LPToken(decodedPoolToken);
@@ -333,5 +292,19 @@ contract FactoryTest is Test {
         RampAController rampAController = new RampAController();
         vm.expectRevert(Initializable.InvalidInitialization.selector);
         rampAController.initialize(30 minutes, 0, governor);
+    }
+
+    function _decodePoolCreatedEvent(Vm.Log[] memory entries)
+        internal
+        pure
+        returns (address, address, address, address, address, address)
+    {
+        bytes32 eventSig = keccak256("PoolCreated(address,address,address,address,address,address)");
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].topics[0] == eventSig) {
+                return abi.decode(entries[i].data, (address, address, address, address, address, address));
+            }
+        }
+        revert("PoolCreated event not found");
     }
 }

--- a/test/Governance.t.sol
+++ b/test/Governance.t.sol
@@ -54,27 +54,25 @@ contract GovernanceTest is Test {
         UpgradeableBeacon rampBeacon = new UpgradeableBeacon(rampImpl, protocolOwner);
 
         ConstantExchangeRateProvider constRate = new ConstantExchangeRateProvider();
-        bytes memory data = abi.encodeCall(
-            SelfPeggingAssetFactory.initialize,
-            (
-                protocolOwner, // owner
-                governor, // governor
-                0, // mint fee
-                0, // swap fee
-                0, // redeem fee
-                0, // offPeg multiplier
-                100, // A
-                30 minutes, // minRampTime
-                address(spaBeacon),
-                address(lpBeacon),
-                address(wlpBeacon),
-                address(rampBeacon),
-                keeperImpl,
-                address(constRate),
-                0, // exchangeRateFeeFactor
-                0 // bufferPercent
-            )
+        SelfPeggingAssetFactory.InitializeArgument memory arg = SelfPeggingAssetFactory.InitializeArgument(
+            protocolOwner, // owner
+            governor, // governor
+            0, // mint fee
+            0, // swap fee
+            0, // redeem fee
+            0, // offPeg multiplier
+            100, // A
+            30 minutes, // minRampTime
+            address(spaBeacon),
+            address(lpBeacon),
+            address(wlpBeacon),
+            address(rampBeacon),
+            keeperImpl,
+            address(constRate),
+            0, // exchangeRateFeeFactor
+            0 // bufferPercent
         );
+        bytes memory data = abi.encodeCall(SelfPeggingAssetFactory.initialize, (arg));
         ERC1967Proxy proxy = new ERC1967Proxy(address(new SelfPeggingAssetFactory()), data);
         factory = SelfPeggingAssetFactory(address(proxy));
 

--- a/test/Keeper.t.sol
+++ b/test/Keeper.t.sol
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Vm } from "forge-std/Vm.sol";
+import { Test, console2 } from "forge-std/Test.sol";
+import { console } from "forge-std/console.sol";
+
+import { SelfPeggingAssetFactory } from "../src/SelfPeggingAssetFactory.sol";
+import { MockToken } from "../src/mock/MockToken.sol";
+import { SelfPeggingAsset } from "../src/SelfPeggingAsset.sol";
+import { LPToken } from "../src/LPToken.sol";
+import { WLPToken } from "../src/WLPToken.sol";
+import { ParameterRegistry, IParameterRegistry } from "../src/periphery/ParameterRegistry.sol";
+import { Keeper } from "../src/periphery/Keeper.sol";
+import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import "../src/misc/ConstantExchangeRateProvider.sol";
+import "../src/mock/MockExchangeRateProvider.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { RampAController } from "../src/periphery/RampAController.sol";
+
+contract KeeperFuzzTest is Test {
+    // Define test accounts
+    address governor = address(1);
+    address curator = address(2);
+    address guardian = address(3);
+    address owner = address(4);
+
+    SelfPeggingAssetFactory factory;
+
+    // Contracts
+    ParameterRegistry parameterRegistry;
+    RampAController rampAController;
+    SelfPeggingAsset spa;
+    LPToken lpToken;
+    WLPToken wlpToken;
+    Keeper keeper;
+
+    uint256 constant DENOMINATOR = 1e10;
+
+    function setUp() public {
+        MockToken tokenA = new MockToken("test 1", "T1", 18);
+        MockToken tokenB = new MockToken("test 2", "T2", 18);
+
+        address selfPeggingAssetImplentation = address(new SelfPeggingAsset());
+        address lpTokenImplentation = address(new LPToken());
+        address wlpTokenImplentation = address(new WLPToken());
+        address rampAControllerImplentation = address(new RampAController());
+        address keeperImplementation = address(new Keeper());
+        UpgradeableBeacon beacon = new UpgradeableBeacon(selfPeggingAssetImplentation, governor);
+        address selfPeggingAssetBeacon = address(beacon);
+
+        beacon = new UpgradeableBeacon(lpTokenImplentation, governor);
+        address lpTokenBeacon = address(beacon);
+
+        beacon = new UpgradeableBeacon(wlpTokenImplentation, governor);
+        address wlpTokenBeacon = address(beacon);
+
+        beacon = new UpgradeableBeacon(rampAControllerImplentation, governor);
+        address rampAControllerBeacon = address(beacon);
+
+        bytes memory data = abi.encodeCall(
+            SelfPeggingAssetFactory.initialize,
+            (
+                owner,
+                governor,
+                0,
+                0,
+                0,
+                0,
+                100,
+                30 minutes,
+                selfPeggingAssetBeacon,
+                lpTokenBeacon,
+                wlpTokenBeacon,
+                rampAControllerBeacon,
+                keeperImplementation,
+                address(new ConstantExchangeRateProvider()),
+                0,
+                0
+            )
+        );
+
+        SelfPeggingAssetFactory.CreatePoolArgument memory arg = SelfPeggingAssetFactory.CreatePoolArgument({
+            tokenA: address(tokenA),
+            tokenB: address(tokenB),
+            tokenAType: SelfPeggingAssetFactory.TokenType.Standard,
+            tokenAOracle: address(0),
+            tokenARateFunctionSig: new bytes(0),
+            tokenADecimalsFunctionSig: new bytes(0),
+            tokenBType: SelfPeggingAssetFactory.TokenType.Standard,
+            tokenBOracle: address(0),
+            tokenBRateFunctionSig: new bytes(0),
+            tokenBDecimalsFunctionSig: new bytes(0)
+        });
+
+        vm.startPrank(owner);
+
+        ERC1967Proxy proxy = new ERC1967Proxy(address(new SelfPeggingAssetFactory()), data);
+        factory = SelfPeggingAssetFactory(address(proxy));
+
+        (wlpToken, keeper, parameterRegistry) = factory.createPool(arg);
+
+        lpToken = LPToken(wlpToken.asset());
+        spa = SelfPeggingAsset(lpToken.pool());
+        rampAController = RampAController(address(spa.rampAController()));
+
+        keeper.grantRole(keeper.GOVERNOR_ROLE(), governor);
+        vm.stopPrank();
+        vm.startPrank(governor);
+
+        keeper.grantRole(keeper.CURATOR_ROLE(), governor);
+        keeper.grantRole(keeper.GUARDIAN_ROLE(), governor);
+        vm.stopPrank();
+    }
+
+    function testParamFuzz(
+        uint8 paramType,
+        uint256 min,
+        uint256 max,
+        uint64 maxDecreasePct,
+        uint64 maxIncreasePct,
+        uint256 oldValue,
+        uint256 newValue
+    )
+        public
+    {
+        paramType = uint8(bound(paramType, 0, 11));
+
+        IParameterRegistry.ParamKey paramKey = getParamKey(paramType);
+        // inputs based on parameter type
+        if (paramType == 0 || paramType == 1 || paramType == 2 || paramType == 5) {
+            vm.assume(oldValue < DENOMINATOR);
+            vm.assume(newValue < DENOMINATOR);
+            vm.assume(max <= DENOMINATOR);
+            vm.assume(min <= max);
+        } else if (paramType == 3) {
+            oldValue = bound(oldValue, DENOMINATOR, 1e18);
+            newValue = bound(newValue, DENOMINATOR, 1e18);
+            max = bound(max, DENOMINATOR, 1e18);
+            min = bound(min, DENOMINATOR, max);
+        } else if (paramType == 4) {
+            vm.assume(oldValue <= 1e18);
+            vm.assume(newValue <= 1e18);
+            vm.assume(max <= 1e18);
+            vm.assume(min <= max);
+        } else if (paramType == 6 || paramType == 7 || paramType == 11) {
+            vm.assume(oldValue <= 365 days);
+            vm.assume(newValue <= 365 days);
+            vm.assume(max <= 365 days);
+            min = bound(min, 0, max);
+        } else if (paramType == 8 || paramType == 9) {
+            vm.assume(oldValue <= 1_000_000_000e18); //1 billion margin
+            vm.assume(newValue <= 1_000_000_000e18); //1 billion margin
+            vm.assume(max <= type(uint256).max);
+            min = bound(min, 0, max);
+        } else if (paramType == 10) {
+            uint256 curretnA = rampAController.getA();
+            oldValue = bound(oldValue, curretnA / 10, curretnA * 10); // defult -90% and +900% is allowed
+            newValue = bound(newValue, 1, 1e6);
+            vm.assume(max <= 1e6);
+            vm.assume(min <= max);
+        }
+        if (paramType == 10) {
+            maxDecreasePct = uint64(bound(maxDecreasePct, 1, type(uint64).max));
+            maxIncreasePct = uint64(bound(maxIncreasePct, 1, type(uint64).max));
+        } else {
+            vm.assume(maxDecreasePct <= DENOMINATOR);
+            vm.assume(maxIncreasePct <= DENOMINATOR);
+        }
+
+        checkParameterBounds(paramType, paramKey, min, max, maxDecreasePct, maxIncreasePct, oldValue, newValue);
+    }
+
+    // function to check parameter bounds
+    function checkParameterBounds(
+        uint8 paramType,
+        IParameterRegistry.ParamKey paramKey,
+        uint256 min,
+        uint256 max,
+        uint64 maxDecreasePct,
+        uint64 maxIncreasePct,
+        uint256 oldValue,
+        uint256 newValue
+    )
+        internal
+    {
+        vm.startPrank(governor);
+        // Set boundaries
+        IParameterRegistry.Bounds memory bounds = IParameterRegistry.Bounds({
+            min: min,
+            max: max,
+            maxDecreasePct: maxDecreasePct,
+            maxIncreasePct: maxIncreasePct
+        });
+
+        // Initial Value
+        setValue(paramType, oldValue);
+        parameterRegistry.setBounds(paramKey, bounds);
+
+        // Get current value
+        uint256 currentValue = getCurrentValue(paramType);
+        assertEq(currentValue, oldValue, "Values did not set");
+
+        // logic for A when curA <= 2
+        bool allowed;
+        if (paramType == 10 && currentValue <= 2) {
+            uint256 maxMultiplier = 11 - currentValue;
+            allowed = newValue <= currentValue * maxMultiplier;
+        } else {
+            bool inAbsoluteBounds = (min == 0 || newValue >= min) && (max == 0 || newValue <= max);
+
+            bool inRelativeBounds = true;
+            if (currentValue != 0 && (maxDecreasePct != 0 || maxIncreasePct != 0)) {
+                if (newValue < currentValue) {
+                    uint256 decreasePct = ((currentValue - newValue) * DENOMINATOR) / currentValue;
+                    inRelativeBounds = decreasePct <= maxDecreasePct;
+                } else if (newValue > currentValue) {
+                    uint256 increasePct = ((newValue - currentValue) * DENOMINATOR) / currentValue;
+                    inRelativeBounds = increasePct <= maxIncreasePct;
+                }
+            }
+            allowed = inAbsoluteBounds && inRelativeBounds;
+        }
+        if (paramType == 10) {
+            uint256 endTime = block.timestamp + 2 hours;
+            if (allowed) {
+                keeper.rampA(newValue, endTime);
+            } else {
+                vm.expectRevert();
+                keeper.rampA(newValue, endTime);
+            }
+        } else {
+            if (allowed) {
+                setValue(paramType, newValue);
+                assertEq(getCurrentValue(paramType), newValue, "Parameter should be updated to newValue");
+            } else {
+                vm.expectRevert();
+                setValue(paramType, newValue);
+            }
+        }
+        vm.stopPrank();
+    }
+
+    // Helper to get parameter key
+    function getParamKey(uint8 paramType) internal pure returns (IParameterRegistry.ParamKey) {
+        if (paramType == 0) return IParameterRegistry.ParamKey.SwapFee;
+        if (paramType == 1) return IParameterRegistry.ParamKey.MintFee;
+        if (paramType == 2) return IParameterRegistry.ParamKey.RedeemFee;
+        if (paramType == 3) return IParameterRegistry.ParamKey.OffPeg;
+        if (paramType == 4) return IParameterRegistry.ParamKey.ExchangeRateFee;
+        if (paramType == 5) return IParameterRegistry.ParamKey.BufferPercent;
+        if (paramType == 6) return IParameterRegistry.ParamKey.DecayPeriod;
+        if (paramType == 7) return IParameterRegistry.ParamKey.RateChangeSkipPeriod;
+        if (paramType == 8) return IParameterRegistry.ParamKey.FeeErrorMargin;
+        if (paramType == 9) return IParameterRegistry.ParamKey.YieldErrorMargin;
+        if (paramType == 10) return IParameterRegistry.ParamKey.A;
+        if (paramType == 11) return IParameterRegistry.ParamKey.MinRampTime;
+        revert("Invalid ParamType");
+    }
+
+    // Helper to set a value
+    function setValue(uint8 paramType, uint256 value) internal {
+        if (paramType == 0) {
+            keeper.setSwapFee(value);
+        } else if (paramType == 1) {
+            keeper.setMintFee(value);
+        } else if (paramType == 2) {
+            keeper.setRedeemFee(value);
+        } else if (paramType == 3) {
+            keeper.setOffPegFeeMultiplier(value);
+        } else if (paramType == 4) {
+            keeper.setExchangeRateFeeFactor(value);
+        } else if (paramType == 5) {
+            keeper.setBufferPercent(value);
+        } else if (paramType == 6) {
+            keeper.setDecayPeriod(value);
+        } else if (paramType == 7) {
+            keeper.setRateChangeSkipPeriod(value);
+        } else if (paramType == 8) {
+            keeper.updateFeeErrorMargin(value);
+        } else if (paramType == 9) {
+            keeper.updateYieldErrorMargin(value);
+        } else if (paramType == 10) {
+            keeper.rampA(value, block.timestamp + 30 minutes);
+            skip(1 hours);
+        } else if (paramType == 11) {
+            keeper.setMinRampTime(value);
+        }
+    }
+
+    // Helper to get current value
+    function getCurrentValue(uint8 paramType) internal view returns (uint256) {
+        if (paramType == 0) return spa.swapFee();
+        if (paramType == 1) return spa.mintFee();
+        if (paramType == 2) return spa.redeemFee();
+        if (paramType == 3) return spa.offPegFeeMultiplier();
+        if (paramType == 4) return spa.exchangeRateFeeFactor();
+        if (paramType == 5) return lpToken.bufferPercent();
+        if (paramType == 6) return spa.decayPeriod();
+        if (paramType == 7) return spa.rateChangeSkipPeriod();
+        if (paramType == 8) return spa.feeErrorMargin();
+        if (paramType == 9) return spa.yieldErrorMargin();
+        if (paramType == 10) return rampAController.getA();
+        if (paramType == 11) return rampAController.minRampTime();
+        revert("Invalid ParamType");
+    }
+}

--- a/test/Keeper.t.sol
+++ b/test/Keeper.t.sol
@@ -58,27 +58,26 @@ contract KeeperFuzzTest is Test {
         beacon = new UpgradeableBeacon(rampAControllerImplentation, governor);
         address rampAControllerBeacon = address(beacon);
 
-        bytes memory data = abi.encodeCall(
-            SelfPeggingAssetFactory.initialize,
-            (
-                owner,
-                governor,
-                0,
-                0,
-                0,
-                0,
-                100,
-                30 minutes,
-                selfPeggingAssetBeacon,
-                lpTokenBeacon,
-                wlpTokenBeacon,
-                rampAControllerBeacon,
-                keeperImplementation,
-                address(new ConstantExchangeRateProvider()),
-                0,
-                0
-            )
+        SelfPeggingAssetFactory.InitializeArgument memory args = SelfPeggingAssetFactory.InitializeArgument(
+            owner,
+            governor,
+            0,
+            0,
+            0,
+            0,
+            100,
+            30 minutes,
+            selfPeggingAssetBeacon,
+            lpTokenBeacon,
+            wlpTokenBeacon,
+            rampAControllerBeacon,
+            keeperImplementation,
+            address(new ConstantExchangeRateProvider()),
+            0,
+            0
         );
+
+        bytes memory data = abi.encodeCall(SelfPeggingAssetFactory.initialize, args);
 
         SelfPeggingAssetFactory.CreatePoolArgument memory arg = SelfPeggingAssetFactory.CreatePoolArgument({
             tokenA: address(tokenA),


### PR DESCRIPTION
- [x] Modified the Keeper check range function to skip the check if no relative range parameters are set.
- [x] Added a check to enforce that the off-peg multiplier can not exceed a minimum absolute threshold.
- [x] Set a default minimum off-peg multiplier value during the registry initialization.