### PR TITLE
Hotfix: Fuzzland reaudit feedback

### DIFF
--- a/src/SelfPeggingAsset.sol
+++ b/src/SelfPeggingAsset.sol
@@ -1296,6 +1296,7 @@ contract SelfPeggingAsset is Initializable, ReentrancyGuardUpgradeable, OwnableU
      */
     function _volatilityFee(uint256 _i, uint256 _baseFee) internal view returns (uint256) {
         uint256 multI = _currentMultiplier(_i);
+        if (multI <= FEE_DENOMINATOR) return 0;
         uint256 diff = multI - FEE_DENOMINATOR;
         return (_baseFee * diff) / FEE_DENOMINATOR;
     }


### PR DESCRIPTION
### Acknowledged
- [x] [Low] `latestRoundData()` has no check for round completeness
- [x] [Info] Incorrect `ParamKey.OffPeg` Initialization
- [x] [Info] Gas Optimization: Merge the for loop in SelfPeggingAsset.initialize

### Fix
- [x] [Info] Missing explicit check for multiplier vs. fee denominator in `_volatilityFee` function